### PR TITLE
Add compatibility for older versions of node

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,7 +1,7 @@
 "use strict";
 
 // Dependencies
-const gitUp = require("git-up");
+var gitUp = require("git-up");
 
 /**
  * gitUrlParse


### PR DESCRIPTION
@IonicaBizau 

I'm building a utility that leverages this library but must run on an older version of Node (0.10 and 0.12). Changing this one line makes it work.  Normally I would not make a change like this but given it looks like the only use of ES2015 in the file, it seems harmless.