### PR TITLE
Adding the port for a stringified url if it is provided

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -88,18 +88,22 @@ function gitUrlParse(url) {
  */
 gitUrlParse.stringify = function (obj, type) {
     type = type || obj.protocol;
+    const port = obj.port ? `:${obj.port}` : '';
     switch (type) {
         case "ssh":
-            return `git@${obj.resource}:${obj.full_name}.git`;
+            if (port)
+              return `ssh://git@${obj.resource}${port}/${obj.full_name}.git`;
+            else
+              return `git@${obj.resource}:${obj.full_name}.git`;
         case "git+ssh":
-            return `git+ssh://git@${obj.resource}/${obj.full_name}.git`;
+            return `git+ssh://git@${obj.resource}${port}/${obj.full_name}.git`;
         case "http":
         case "https":
             let token = "";
             if (obj.token) {
               token = buildToken(obj);
             }
-            return `${type}://${token}${obj.resource}/${obj.full_name}`;
+            return `${type}://${token}${obj.resource}${port}/${obj.full_name}`;
         default:
             return obj.href;
     }

--- a/test/index.js
+++ b/test/index.js
@@ -120,5 +120,9 @@ tester.describe("parse urls", test => {
         var res = gitUrlParse("https://owner@bitbucket.org/owner/name");
         res.token = "token";
         test.expect(res.toString()).toBe("https://x-token-auth:token@bitbucket.org/owner/name");
+
+        var res = gitUrlParse("git@github.com:owner/name.git");
+        res.port = 22;
+        test.expect(res.toString()).toBe("ssh://git@github.com:22/owner/name.git");
     });
 });


### PR DESCRIPTION
This will add a specified port to a stringified url when it is relevant. This should fix the case where if you parse an ssh url with a custom port, then stringify the result, the port will be lost.

``` javascript
import GitUrlParse from 'git-url-parse';

const url = GitUrlParse('ssh://git@mygitserver.com:1234/user/repo.git');
GitUrlParse.stringify(url);  // git@mygitserver.com:user/repo.git  <-- port is missing

// With change
GitUrlParse.stringify(url);  // ssh://git@mygitserver.com:1234/user/repo.git'
```

It should also fix the problem for custom ports on http/https urls, though I believe parsing those improperly determines those urls as being `ssh` protocols.
