### PR TITLE
Adds support for non-git usernames in stringified url

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -89,14 +89,16 @@ function gitUrlParse(url) {
 gitUrlParse.stringify = function (obj, type) {
     type = type || obj.protocol;
     const port = obj.port ? `:${obj.port}` : '';
+    const user = obj.user || 'git';
     switch (type) {
         case "ssh":
             if (port)
-              return `ssh://git@${obj.resource}${port}/${obj.full_name}.git`;
+                return `ssh://${user}@${obj.resource}${port}/${obj.full_name}.git`;
             else
-              return `git@${obj.resource}:${obj.full_name}.git`;
+                return `${user}@${obj.resource}:${obj.full_name}.git`;
         case "git+ssh":
-            return `git+ssh://git@${obj.resource}${port}/${obj.full_name}.git`;
+        case "ssh+git":
+            return `${type}://${user}@${obj.resource}${port}/${obj.full_name}.git`;
         case "http":
         case "https":
             let token = "";

--- a/lib/index.js
+++ b/lib/index.js
@@ -87,7 +87,7 @@ function gitUrlParse(url) {
  * @return {String} The stringified url.
  */
 gitUrlParse.stringify = function (obj, type) {
-    type = type || obj.protocol;
+    type = type || ((obj.protocols && obj.protocols.length) ? obj.protocols.join('+') : obj.protocol);
     const port = obj.port ? `:${obj.port}` : '';
     const user = obj.user || 'git';
     switch (type) {

--- a/test/index.js
+++ b/test/index.js
@@ -124,5 +124,18 @@ tester.describe("parse urls", test => {
         var res = gitUrlParse("git@github.com:owner/name.git");
         res.port = 22;
         test.expect(res.toString()).toBe("ssh://git@github.com:22/owner/name.git");
+
+        var res = gitUrlParse("user@github.com:owner/name.git");
+        test.expect(res.toString()).toBe("user@github.com:owner/name.git");
+
+        var res = gitUrlParse("git@github.com:owner/name.git");
+        res.port = 22;
+        res.user = "user";
+        test.expect(res.toString()).toBe("ssh://user@github.com:22/owner/name.git");
+
+        var res = gitUrlParse("git+ssh://git@github.com/owner/name.git");
+        res.port = 22;
+        res.user = "user";
+        test.expect(res.toString()).toBe("git+ssh://user@github.com:22/owner/name.git");
     });
 });


### PR DESCRIPTION
This will use whatever username is specified for ssh urls instead of the hardcoded `git` value.

```
import GitUrlParse from 'git-url-parse';

const url = GitUrlParse('ssh://myuser@mygitserver.com/owner/repo.git');
GitUrlParse.stringify(url); // 'git@mygitserver.com:owner/repo.git' <-- wrong username

// With change
GitUrlParse.stringify(url); // 'myuser@mygitserver.com:owner/repo.git'
```

I also added a change that will allow multiple protocols (`ssh+git`) to be stringified properly even if the type isn't specified in the method call.