### PR TITLE
Handle VSTS legacy URLs

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -69,9 +69,12 @@ function gitUrlParse(url) {
             if (splits.length === 2) {
                 urlInfo.owner = splits[1];
                 urlInfo.name = splits[1];
-            } else if (splits.length > 2) {
-                urlInfo.owner = splits[0];
-                urlInfo.name = splits[2];
+            } else if (splits.length === 3) {
+              urlInfo.owner = splits[0] === 'DefaultCollection' ? splits[2] : splits[0];
+              urlInfo.name = splits[2];
+            } else if (splits.length === 4) {
+              urlInfo.owner = splits[1];
+              urlInfo.name = splits[3];
             }
             urlInfo.organization = urlInfo.owner;
             break;

--- a/test/index.js
+++ b/test/index.js
@@ -141,6 +141,17 @@ tester.describe("parse urls", test => {
         test.expect(res.source).toBe("visualstudio.com");
         test.expect(res.owner).toBe("MyProject");
         test.expect(res.name).toBe("MyRepo");
+
+        // Legacy URLs
+        res = gitUrlParse("https://companyname.visualstudio.com/DefaultCollection/_git/MyRepo");
+        test.expect(res.source).toBe("visualstudio.com");
+        test.expect(res.owner).toBe("MyRepo");
+        test.expect(res.name).toBe("MyRepo");
+
+        res = gitUrlParse("https://companyname.visualstudio.com/DefaultCollection/MyProject/_git/MyRepo");
+        test.expect(res.source).toBe("visualstudio.com");
+        test.expect(res.owner).toBe("MyProject");
+        test.expect(res.name).toBe("MyRepo");
     });
 
     // Handle URL encoded names of owners and repositories


### PR DESCRIPTION
Fixes: https://github.com/IonicaBizau/git-url-parse/issues/58

VSTS legacy URLs used to include the string `DefaultCollection` in the URL path, and I failed to handle that case when I originally implemented VSTS URL parsing. This should fix the parsing of these legacy URLs. 