### PR TITLE
Fix VSTS URL parsing and stringifying

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -67,14 +67,23 @@ function gitUrlParse(url) {
             if (splits.length === 2) {
                 urlInfo.owner = splits[1];
                 urlInfo.name = splits[1];
+                urlInfo.full_name = '_git/' + urlInfo.name;
             } else if (splits.length === 3) {
-              urlInfo.owner = splits[0] === 'DefaultCollection' ? splits[2] : splits[0];
               urlInfo.name = splits[2];
+              if (splits[0] === 'DefaultCollection') {
+                urlInfo.owner =  splits[2];
+                urlInfo.organization = splits[0];
+                urlInfo.full_name = urlInfo.organization + '/_git/' + urlInfo.name;
+              } else {
+                urlInfo.owner = splits[0];
+                urlInfo.full_name = urlInfo.owner + '/_git/' + urlInfo.name;
+              }
             } else if (splits.length === 4) {
+              urlInfo.organization = splits[0];
               urlInfo.owner = splits[1];
               urlInfo.name = splits[3];
+              urlInfo.full_name = urlInfo.organization + '/' + urlInfo.owner + '/_git/' + urlInfo.name;
             }
-            urlInfo.organization = urlInfo.owner;
             break;
         default:
             splits = urlInfo.name.split("/");
@@ -104,10 +113,12 @@ function gitUrlParse(url) {
             break;
     }
 
-    urlInfo.full_name = urlInfo.owner;
-    if (urlInfo.name) {
-        urlInfo.full_name && (urlInfo.full_name += "/");
-        urlInfo.full_name += urlInfo.name;
+    if (!urlInfo.full_name) {
+        urlInfo.full_name = urlInfo.owner;
+        if (urlInfo.name) {
+            urlInfo.full_name && (urlInfo.full_name += "/");
+            urlInfo.full_name += urlInfo.name;
+        }
     }
 
     return urlInfo;

--- a/test/index.js
+++ b/test/index.js
@@ -146,22 +146,28 @@ tester.describe("parse urls", test => {
         test.expect(res.source).toBe("visualstudio.com");
         test.expect(res.owner).toBe("MyProject");
         test.expect(res.name).toBe("MyProject");
+        test.expect(res.toString()).toBe("https://companyname.visualstudio.com/_git/MyProject");
 
         res = gitUrlParse("https://companyname.visualstudio.com/MyProject/_git/MyRepo");
         test.expect(res.source).toBe("visualstudio.com");
         test.expect(res.owner).toBe("MyProject");
         test.expect(res.name).toBe("MyRepo");
+        test.expect(res.toString()).toBe("https://companyname.visualstudio.com/MyProject/_git/MyRepo");
 
         // Legacy URLs
         res = gitUrlParse("https://companyname.visualstudio.com/DefaultCollection/_git/MyRepo");
         test.expect(res.source).toBe("visualstudio.com");
         test.expect(res.owner).toBe("MyRepo");
         test.expect(res.name).toBe("MyRepo");
+        test.expect(res.organization).toBe("DefaultCollection");
+        test.expect(res.toString()).toBe("https://companyname.visualstudio.com/DefaultCollection/_git/MyRepo");
 
         res = gitUrlParse("https://companyname.visualstudio.com/DefaultCollection/MyProject/_git/MyRepo");
         test.expect(res.source).toBe("visualstudio.com");
         test.expect(res.owner).toBe("MyProject");
         test.expect(res.name).toBe("MyRepo");
+        test.expect(res.organization).toBe("DefaultCollection");
+        test.expect(res.toString()).toBe("https://companyname.visualstudio.com/DefaultCollection/MyProject/_git/MyRepo");
     });
 
     // Handle URL encoded names of owners and repositories


### PR DESCRIPTION
Fix #67, Fix #70

This fix both the parsing and stringifying of VSTS URL, in particular:
- Parse the `full_name` based on the different VSTS URL format
- Fix parsing of `organization`
- Preserve the original URL when stringifying
- Add tests for `toString()`

I'm not familiar with VSTS but what I found in the docs seems to be covered by the tests.

/cc @roger199585  