### PR TITLE
Fix parsing of git_suffix

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -48,14 +48,14 @@ function gitUrlParse(url) {
         return gitUrlParse.stringify(this, type);
     };
 
-    const parsedResource = parseDomain(urlInfo.resource)
-    urlInfo.source = parsedResource ? parsedResource.domain + '.' + parsedResource.tld : urlInfo.resource
+    const parsedResource = parseDomain(urlInfo.resource);
+    urlInfo.source = parsedResource ? parsedResource.domain + '.' + parsedResource.tld : urlInfo.resource;
 
     // Note: Some hosting services (e.g. Visual Studio Team Services) allow whitespace characters
     // in the repository and owner names so we decode the URL pieces to get the correct result
+    urlInfo.git_suffix = /\.git$/.test(urlInfo.pathname);
     urlInfo.name = decodeURIComponent(urlInfo.pathname.substring(1).replace(/\.git$/, ""));
     urlInfo.owner = decodeURIComponent(urlInfo.user);
-    urlInfo.git_suffix = false;
 
     switch (urlInfo.source) {
         case "cloudforge.com":

--- a/test/index.js
+++ b/test/index.js
@@ -230,20 +230,20 @@ tester.describe("parse urls", test => {
         test.expect(res.owner).toBe("a/b/c");
         test.expect(res.name).toBe("d");
         test.expect(res.href).toBe("git@gitlab.com:a/b/c/d.git");
-        test.expect(res.toString("https")).toBe("https://gitlab.com/a/b/c/d");
-        test.expect(res.toString("git+ssh")).toBe("git+ssh://git@gitlab.com/a/b/c/d");
-        test.expect(res.toString("ssh")).toBe("git@gitlab.com:a/b/c/d");
-        test.expect(res.toString()).toBe("git@gitlab.com:a/b/c/d");
+        test.expect(res.toString("https")).toBe("https://gitlab.com/a/b/c/d.git");
+        test.expect(res.toString("git+ssh")).toBe("git+ssh://git@gitlab.com/a/b/c/d.git");
+        test.expect(res.toString("ssh")).toBe("git@gitlab.com:a/b/c/d.git");
+        test.expect(res.toString()).toBe("git@gitlab.com:a/b/c/d.git");
     });
 
     test.should("stringify token", () => {
         var res = gitUrlParse("https://github.com/owner/name.git");
         res.token = "token";
-        test.expect(res.toString()).toBe("https://token@github.com/owner/name");
+        test.expect(res.toString()).toBe("https://token@github.com/owner/name.git");
 
         var res = gitUrlParse("https://gitlab.com/group/subgroup/name.git");
         res.token = "token";
-        test.expect(res.toString()).toBe("https://token@gitlab.com/group/subgroup/name");
+        test.expect(res.toString()).toBe("https://token@gitlab.com/group/subgroup/name.git");
 
         var res = gitUrlParse("https://owner@bitbucket.org/owner/name");
         res.token = "token";
@@ -254,25 +254,25 @@ tester.describe("parse urls", test => {
         test.expect(res.toString()).toBe("ssh://git@github.com:22/owner/name");
 
         var res = gitUrlParse("user@github.com:owner/name.git");
-        test.expect(res.toString()).toBe("user@github.com:owner/name");
+        test.expect(res.toString()).toBe("user@github.com:owner/name.git");
 
         var res = gitUrlParse("git@github.com:owner/name.git");
         res.port = 22;
         res.user = "user";
-        test.expect(res.toString()).toBe("ssh://user@github.com:22/owner/name");
+        test.expect(res.toString()).toBe("ssh://user@github.com:22/owner/name.git");
 
         var res = gitUrlParse("git+ssh://git@github.com/owner/name.git");
         res.port = 22;
         res.user = "user";
-        test.expect(res.toString()).toBe("git+ssh://user@github.com:22/owner/name");
+        test.expect(res.toString()).toBe("git+ssh://user@github.com:22/owner/name.git");
 
         var res = gitUrlParse("https://github.com/owner/name.git");
         res.user = "user";
-        test.expect(res.toString()).toBe("https://user@github.com/owner/name");
+        test.expect(res.toString()).toBe("https://user@github.com/owner/name.git");
 
         var res = gitUrlParse("http://github.com/owner/name.git");
         res.user = "user";
-        test.expect(res.toString()).toBe("http://user@github.com/owner/name");
+        test.expect(res.toString()).toBe("http://user@github.com/owner/name.git");
     });
 
     test.it("custom url", () => {


### PR DESCRIPTION
Fix #69

In the parsed result, `git_suffix` is now set to `true` if the URL ends with `.git`.
Users can still change its value before calling `toString()` 