### PR TITLE
Fix `name` parsing

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -55,7 +55,7 @@ function gitUrlParse(url) {
     // Note: Some hosting services (e.g. Visual Studio Team Services) allow whitespace characters
     // in the repository and owner names so we decode the URL pieces to get the correct result
     urlInfo.git_suffix = /\.git$/.test(urlInfo.pathname);
-    urlInfo.name = decodeURIComponent(urlInfo.pathname.substring(1).replace(/\.git$/, ""));
+    urlInfo.name = decodeURIComponent(urlInfo.pathname.replace(/^\//, '').replace(/\.git$/, ""));
     urlInfo.owner = decodeURIComponent(urlInfo.user);
 
     switch (urlInfo.source) {


### PR DESCRIPTION
Fix #75

When the path is relative the `urlInfo.pathname` doesn't starts with `/` so `substring(1)` removed the first character. The fix is to remove the first character only if it's a `/`.