### PR TITLE
 Fix parsing of `source` with 2 parts SLD

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -49,8 +49,8 @@ function gitUrlParse(url) {
         return gitUrlParse.stringify(this, type);
     };
 
-    const parsedResource = parseDomain(urlInfo.resource);
-    urlInfo.source = parsedResource ? parsedResource.domain + '.' + parsedResource.tld : urlInfo.resource;
+    const parsedResource = parseDomain(urlInfo.resource)
+    urlInfo.source = parsedResource.domain + '.' + parsedResource.tld;
 
     // Note: Some hosting services (e.g. Visual Studio Team Services) allow whitespace characters
     // in the repository and owner names so we decode the URL pieces to get the correct result

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,7 +1,6 @@
 "use strict";
 
 const gitUp = require("git-up");
-const parseDomain = require('parse-domain');
 
 /**
  * gitUrlParse
@@ -45,12 +44,14 @@ function gitUrlParse(url) {
       , splits = null
       ;
 
-      urlInfo.toString = function (type) {
+    urlInfo.toString = function (type) {
         return gitUrlParse.stringify(this, type);
     };
 
-    const parsedResource = parseDomain(urlInfo.resource)
-    urlInfo.source = parsedResource.domain + '.' + parsedResource.tld;
+    urlInfo.source = sourceParts.length > 2
+                   ? sourceParts.slice(-2).join(".")
+                   : urlInfo.source = urlInfo.resource
+                   ;
 
     // Note: Some hosting services (e.g. Visual Studio Team Services) allow whitespace characters
     // in the repository and owner names so we decode the URL pieces to get the correct result

--- a/lib/index.js
+++ b/lib/index.js
@@ -49,7 +49,7 @@ function gitUrlParse(url) {
     };
 
     urlInfo.source = sourceParts.length > 2
-                   ? sourceParts.slice(-2).join(".")
+                   ? sourceParts.slice(1 - sourceParts.length).join(".")
                    : urlInfo.source = urlInfo.resource
                    ;
 
@@ -60,9 +60,10 @@ function gitUrlParse(url) {
     urlInfo.owner = decodeURIComponent(urlInfo.user);
 
     switch (urlInfo.source) {
-        case "cloudforge.com":
+        case "git.cloudforge.com":
             urlInfo.owner = urlInfo.user;
             urlInfo.organization = sourceParts[0];
+            urlInfo.source = "cloudforge.com";
             break;
         case "visualstudio.com":
             splits = urlInfo.name.split("/");

--- a/package.json
+++ b/package.json
@@ -29,8 +29,7 @@
     "test": "test"
   },
   "dependencies": {
-    "git-up": "^2.0.0",
-    "parse-domain": "^2.0.0"
+    "git-up": "^2.0.0"
   },
   "devDependencies": {
     "browserify": "^13.0.1",

--- a/test/index.js
+++ b/test/index.js
@@ -280,9 +280,4 @@ tester.describe("parse urls", test => {
         res.user = "user";
         test.expect(res.toString()).toBe("http://user@github.com/owner/name.git");
     });
-
-    test.should("custom url", () => {
-        var res = gitUrlParse("https://git.test.com.cn/a/b");
-        test.expect(res.source).toBe('test.com.cn');
-    })
 });

--- a/test/index.js
+++ b/test/index.js
@@ -170,6 +170,14 @@ tester.describe("parse urls", test => {
         test.expect(res.toString()).toBe("https://companyname.visualstudio.com/DefaultCollection/MyProject/_git/MyRepo");
     });
 
+    // custom git hosted URL with 2 parts SLD
+    test.should("parse Gih hosted urls with two parts SLD", () => {
+        var res = gitUrlParse("https://domain.git.com.cn/owner/name.git");
+        test.expect(res.source).toBe("git.com.cn");
+        test.expect(res.owner).toBe("owner");
+        test.expect(res.name).toBe("name");
+    });
+
     // Handle URL encoded names of owners and repositories
     test.should("https URLs with URL encoded characters", () => {
       var res = gitUrlParse("https://companyname.visualstudio.com/My%20Project/_git/My%20Repo");

--- a/test/index.js
+++ b/test/index.js
@@ -281,13 +281,8 @@ tester.describe("parse urls", test => {
         test.expect(res.toString()).toBe("http://user@github.com/owner/name.git");
     });
 
-    test.it("custom url", () => {
+    test.should("custom url", () => {
         var res = gitUrlParse("https://git.test.com.cn/a/b");
         test.expect(res.source).toBe('test.com.cn');
-    })
-
-    test.it("local urls", () => {
-        var res = gitUrlParse("http://machine:8080/tfs/Collection/Project.Name/_git/repository");
-        test.expect(res.source).toBe('machine');
     })
 });


### PR DESCRIPTION
Different implement to fix #56 that doesn't rely on `parse-domain`.
Fix #79.

To be honest I'm not sure #56 is actually an issue. The documentation indicate that the `source` field is meant for "The Git provider (e.g. "github.com")" which implies the parsing might differ for each specific Git provider and the result is supposed to be an actual Git provider.

The issue reported in #56 mentions a problem with parsing `https://git.test.com.cn/a/b`, however `test.com.cn` is not a Git provider.
The proper solution for #56 would have been to make an exception for that specific Git host, the same way we [do for Cloudforge](https://github.com/IonicaBizau/git-url-parse/blob/master/lib/index.js#L62) for example. However the name of the Git host was not provided in #56....

If you agree that the proper way of handling that is to make an exception case for that specific Git hosted once the author of #56 provides it, then I can remove the commit 
13dae80 from this PR and we can just revert the 2 commits from #56. Let me know!
