### PR TITLE
git-url-parse 10.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "git-url-parse",
-  "version": "9.0.2",
+  "version": "10.0.0",
   "description": "A high level git url parser for common git providers.",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "git-url-parse",
-  "version": "10.0.0",
+  "version": "9.0.2",
   "description": "A high level git url parser for common git providers.",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "git-url-parse",
-  "version": "10.0.0",
+  "version": "10.0.1",
   "description": "A high level git url parser for common git providers.",
   "main": "lib/index.js",
   "scripts": {


### PR DESCRIPTION
Fix parsing of `source` with 2 parts SLD

/cc #80 Thanks @pvdlg!