### PR TITLE
Fix parsing of GitLab URLs with /-/ scope

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -141,10 +141,12 @@ function gitUrlParse(url) {
             splits = urlInfo.name.split("/");
             let nameIndex = splits.length - 1;
             if (splits.length >= 2) {
+                const dashIndex = splits.indexOf("-", 2)
                 const blobIndex = splits.indexOf("blob", 2);
                 const treeIndex = splits.indexOf("tree", 2);
                 const commitIndex = splits.indexOf("commit", 2);
-                nameIndex = blobIndex > 0 ? blobIndex - 1
+                nameIndex = dashIndex > 0 ? dashIndex - 1
+                          : blobIndex > 0 ? blobIndex - 1
                           : treeIndex > 0 ? treeIndex - 1
                           : commitIndex > 0 ? commitIndex - 1
                           : nameIndex;
@@ -159,11 +161,12 @@ function gitUrlParse(url) {
             urlInfo.ref = "";
             urlInfo.filepathtype = "";
             urlInfo.filepath = "";
-            if ((splits.length > nameIndex + 2) && (["blob", "tree"].indexOf(splits[nameIndex + 1]) >= 0)) {
-                urlInfo.filepathtype = splits[nameIndex + 1];
-                urlInfo.ref = splits[nameIndex + 2];
-                if (splits.length > nameIndex + 3) {
-                    urlInfo.filepath = splits.slice(nameIndex + 3).join('/');
+            const offsetNameIndex = splits.length > nameIndex && splits[nameIndex+1] === "-" ? nameIndex + 1 : nameIndex;
+            if ((splits.length > offsetNameIndex + 2) && (["blob", "tree"].indexOf(splits[offsetNameIndex + 1]) >= 0)) {
+                urlInfo.filepathtype = splits[offsetNameIndex + 1];
+                urlInfo.ref = splits[offsetNameIndex + 2];
+                if (splits.length > offsetNameIndex + 3) {
+                    urlInfo.filepath = splits.slice(offsetNameIndex + 3).join('/');
                 }
             }
             urlInfo.organization = urlInfo.owner;

--- a/test/index.js
+++ b/test/index.js
@@ -241,6 +241,16 @@ tester.describe("parse urls", test => {
         test.expect(res.ref).toBe("master");
         test.expect(res.filepathtype).toBe("blob");
         test.expect(res.filepath).toBe("test/index.js");
+
+        res = gitUrlParse("https://gitlab.com/a/b/c/d/-/blob/master/test/index.js");
+        test.expect(res.protocol).toBe("https");
+        test.expect(res.source).toBe("gitlab.com");
+        test.expect(res.owner).toBe("a/b/c");
+        test.expect(res.name).toBe("d");
+        test.expect(res.href).toBe("https://gitlab.com/a/b/c/d/-/blob/master/test/index.js");
+        test.expect(res.ref).toBe("master");
+        test.expect(res.filepathtype).toBe("blob");
+        test.expect(res.filepath).toBe("test/index.js");
     });
 
     // shorthand urls


### PR DESCRIPTION
Gitlab introduced the [/-/ scope][1] to avoid ambiguities when routing.
This means that some URLs now contain a further element in the path and
parsing breaks for these URLs.

This fix takes the new potential element in the path into account.

[1]: https://docs.gitlab.com/ee/development/routing.html

Closes #107