### PR TITLE
Add filepath support for Azure DevOps

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -135,6 +135,9 @@ function gitUrlParse(url) {
                 urlInfo.name = splits[3];
                 urlInfo.full_name = urlInfo.organization + '/' + urlInfo.owner + '/_git/' + urlInfo.name;
               }
+              if(urlInfo.query && urlInfo.query['path']) {
+                urlInfo.filepath = urlInfo.query['path'].replace(/^\/+/g, ''); // Strip leading slash (/)
+              }
               break;
             }
         default:

--- a/test/index.js
+++ b/test/index.js
@@ -145,16 +145,18 @@ tester.describe("parse urls", test => {
     // https Azure DevOps (formerly Visual Studio Team Services)
     test.should("parse Azure DevOps HTTPS urls", () => {
         // Parse URL for matching project and repo names
-        var res = gitUrlParse("https://dev.azure.com/MyOrganization/MatchedName/MyTeam/_git/MatchedName");
+        var res = gitUrlParse("https://dev.azure.com/MyOrganization/MatchedName/MyTeam/_git/MatchedName?path=%2Ftest%2Findex.js");
         test.expect(res.source).toBe("azure.com");
         test.expect(res.owner).toBe("MatchedName");
         test.expect(res.name).toBe("MatchedName");
+        test.expect(res.filepath).toBe("test/index.js");
 
         // Parse URL for non-matching project and repo names
-        res = gitUrlParse("https://dev.azure.com/MyOrganization/MyProject/_git/MyRepo");
+        res = gitUrlParse("https://dev.azure.com/MyOrganization/MyProject/_git/MyRepo?path=%2Ftest%2Findex.js");
         test.expect(res.source).toBe("azure.com");
         test.expect(res.owner).toBe("MyProject");
         test.expect(res.name).toBe("MyRepo");
+        test.expect(res.filepath).toBe("test/index.js");
     });
 
     // ssh Azure DevOps (formerly Visual Studio Team Services)


### PR DESCRIPTION
This adds support for setting the `filepath` property when the `path` query parameter is present.

Closes #110 