### PR TITLE
Add support for mapping Bitbucket Server clone urls

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -189,13 +189,16 @@ function gitUrlParse(url) {
     }
     // Bitbucket Server
     if(urlInfo.owner.startsWith("scm/")) {
+        urlInfo.source = "bitbucket-server";
         urlInfo.owner = urlInfo.owner.replace("scm/","");
         urlInfo.organization = urlInfo.owner;
+        urlInfo.full_name = `${urlInfo.owner}/${urlInfo.name}`
     }
 
     const bitbucket = /(projects|users)\/(.*?)\/repos\/(.*?)\/(raw|browse)\/(.*?)$/
     const matches = bitbucket.exec(urlInfo.pathname)
     if(matches != null) {
+        urlInfo.source = "bitbucket-server";
         if (matches[1] === "users") {
             urlInfo.owner = "~" + matches[2];
         } else {
@@ -206,6 +209,7 @@ function gitUrlParse(url) {
         urlInfo.name = matches[3];
         urlInfo.filepathtype = matches[4];
         urlInfo.filepath = matches[5];
+        urlInfo.full_name = `${urlInfo.owner}/${urlInfo.name}`
 
         if(urlInfo.query.at) {
             urlInfo.ref = urlInfo.query.at;
@@ -247,7 +251,7 @@ gitUrlParse.stringify = function (obj, type) {
             const auth = obj.token
               ? buildToken(obj) : obj.user && (obj.protocols.includes('http') || obj.protocols.includes('https'))
                 ? `${obj.user}@` : "";
-            return `${type}://${auth}${obj.resource}${port}/${obj.full_name}${maybeGitSuffix}`;
+            return `${type}://${auth}${obj.resource}${port}/${buildPath(obj)}${maybeGitSuffix}`;
         default:
             return obj.href;
     }
@@ -269,6 +273,16 @@ function buildToken(obj) {
       default:
         return `${obj.token}@`
     }
+}
+
+function buildPath(obj) {
+  switch(obj.source) {
+    case "bitbucket-server":
+      return `scm/${obj.full_name}`;
+    default:
+      return `${obj.full_name}`;
+
+  }
 }
 
 module.exports = gitUrlParse;

--- a/test/index.js
+++ b/test/index.js
@@ -194,6 +194,7 @@ tester.describe("parse urls", test => {
         test.expect(res.filepath).toBe("README.md");
         test.expect(res.ref).toBe("master");
         test.expect(res.filepathtype).toBe("browse");
+        test.expect(res.toString()).toBe("https://bitbucket.mycompany.com/scm/owner/name")
     });
 
     test.should("parse Bitbucket Server personal repository browse url", () => {
@@ -212,6 +213,7 @@ tester.describe("parse urls", test => {
         test.expect(res.filepath).toBe("README.md");
         test.expect(res.ref).toBe("master");
         test.expect(res.filepathtype).toBe("raw");
+        test.expect(res.toString()).toBe("https://bitbucket.mycompany.com/scm/~owner/name")
     });
 
     test.should("parse Bitbucket Server personal repository clone over ssh", () => {
@@ -225,6 +227,7 @@ tester.describe("parse urls", test => {
         test.expect(res.owner).toBe("~owner");
         test.expect(res.organization).toBe("~owner")
         test.expect(res.name).toBe("name");
+        test.expect(res.full_name).toBe("~owner/name")
     });
 
     // https cloudforge


### PR DESCRIPTION
This pull request aims to add support for providing a correct clone url for Bitbucket Server when you are calling gitInfo.toString("https")`

I have used the `source` property for specifying that its a bitbucket-server instance, however I would love some feedback on that solution. In addition, giving a correct clone https url based on an ssh clone address is difficult and is therefore out of scope for this PR.