### PR TITLE
Fix Bitbucket Server URL when it only ends with /browse

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -193,7 +193,7 @@ function gitUrlParse(url) {
         urlInfo.organization = urlInfo.owner;
     }
 
-    const bitbucket = /(projects|users)\/(.*?)\/repos\/(.*?)\/(raw|browse)\/?(.*?)$/
+    const bitbucket = /(projects|users)\/(.*?)\/repos\/(.*?)\/(raw|browse)(?:\/(?:$|(.+?)))?$/
     const matches = bitbucket.exec(urlInfo.pathname)
     if(matches != null) {
         if (matches[1] === "users") {

--- a/lib/index.js
+++ b/lib/index.js
@@ -193,7 +193,7 @@ function gitUrlParse(url) {
         urlInfo.organization = urlInfo.owner;
     }
 
-    const bitbucket = /(projects|users)\/(.*?)\/repos\/(.*?)\/(raw|browse)\/(.*?)$/
+    const bitbucket = /(projects|users)\/(.*?)\/repos\/(.*?)\/(raw|browse)\/?(.*?)$/
     const matches = bitbucket.exec(urlInfo.pathname)
     if(matches != null) {
         if (matches[1] === "users") {

--- a/test/index.js
+++ b/test/index.js
@@ -194,6 +194,20 @@ tester.describe("parse urls", test => {
         test.expect(res.filepathtype).toBe("browse");
     });
 
+    test.should("parse Bitbucket server browse repository with a trailing slash", () => {
+        var res = gitUrlParse("https://bitbucket.mycompany.com/projects/owner/repos/name/browse/");
+        test.expect(res.owner).toBe("owner");
+        test.expect(res.name).toBe("name");
+        test.expect(res.filepathtype).toBe("browse");
+    });
+
+    test.should("not parse correctly unknown Bitbucket server URL", () => {
+        var res = gitUrlParse("https://bitbucket.mycompany.com/projects/owner/repos/name/browseunknown");
+        test.expect(res.owner === "owner").toBe(false);
+        test.expect(res.name === "name").toBe(false);
+        test.expect(res.filepathtype === "browse").toBe(false);
+    });
+
     test.should("parse Bitbucket server browse file", () => {
         var res = gitUrlParse("https://bitbucket.mycompany.com/projects/owner/repos/name/browse/README.md?at=master");
         test.expect(res.owner).toBe("owner");

--- a/test/index.js
+++ b/test/index.js
@@ -187,6 +187,13 @@ tester.describe("parse urls", test => {
         test.expect(res.filepathtype).toBe("raw");
     });
 
+    test.should("parse Bitbucket server browse repository", () => {
+        var res = gitUrlParse("https://bitbucket.mycompany.com/projects/owner/repos/name/browse");
+        test.expect(res.owner).toBe("owner");
+        test.expect(res.name).toBe("name");
+        test.expect(res.filepathtype).toBe("browse");
+    });
+
     test.should("parse Bitbucket server browse file", () => {
         var res = gitUrlParse("https://bitbucket.mycompany.com/projects/owner/repos/name/browse/README.md?at=master");
         test.expect(res.owner).toBe("owner");


### PR DESCRIPTION
When we have to parse a Bitbucket Server URL that ends with `browse` such as `https://bitbucket.mycompany.com/projects/some-owner/repos/some-repo-name/browse` which is a valid URL, the actual result is:
- `name` = `browse`;
- `owner` = `projects/some-owner/repos/some-repo-name`.

The expected result should be:
- `name` = `some-repo-name`;
- `owner` = `some-owner`.