### PR TITLE
Add support for Bitbucket Server repository root and commit endpoints

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -198,7 +198,7 @@ function gitUrlParse(url) {
         urlInfo.full_name = `${urlInfo.owner}/${urlInfo.name}`
     }
 
-    const bitbucket = /(projects|users)\/(.*?)\/repos\/(.*?)\/(raw|browse)(?:\/(?:$|(.+?)))?$/
+    const bitbucket = /(projects|users)\/(.*?)\/repos\/(.*?)((\/.*$)|$)/
     const matches = bitbucket.exec(urlInfo.pathname)
     if(matches != null) {
         urlInfo.source = "bitbucket-server";
@@ -210,8 +210,18 @@ function gitUrlParse(url) {
 
         urlInfo.organization = urlInfo.owner;
         urlInfo.name = matches[3];
-        urlInfo.filepathtype = matches[4];
-        urlInfo.filepath = matches[5];
+
+        splits = matches[4].split("/");
+        if(splits.length > 1) {
+          if(["raw","browse"].indexOf(splits[1]) >= 0) {
+            urlInfo.filepathtype = splits[1];
+            if (splits.length > 2) {
+              urlInfo.filepath = splits[2];
+            }
+          } else if(splits[1] === "commits" && splits.length > 2) {
+            urlInfo.commit = splits[2];
+          }
+        }
         urlInfo.full_name = `${urlInfo.owner}/${urlInfo.name}`
 
         if(urlInfo.query.at) {

--- a/test/index.js
+++ b/test/index.js
@@ -201,13 +201,6 @@ tester.describe("parse urls", test => {
         test.expect(res.filepathtype).toBe("browse");
     });
 
-    test.should("not parse correctly unknown Bitbucket server URL", () => {
-        var res = gitUrlParse("https://bitbucket.mycompany.com/projects/owner/repos/name/browseunknown");
-        test.expect(res.owner === "owner").toBe(false);
-        test.expect(res.name === "name").toBe(false);
-        test.expect(res.filepathtype === "browse").toBe(false);
-    });
-
     test.should("parse Bitbucket server browse file", () => {
         var res = gitUrlParse("https://bitbucket.mycompany.com/projects/owner/repos/name/browse/README.md?at=master");
         test.expect(res.owner).toBe("owner");
@@ -249,6 +242,31 @@ tester.describe("parse urls", test => {
         test.expect(res.organization).toBe("~owner")
         test.expect(res.name).toBe("name");
         test.expect(res.full_name).toBe("~owner/name")
+    });
+
+    test.should("parse Bitbucket Server root endpoint", () => {
+      var res = gitUrlParse("https://bitbucket.mycompany.com/projects/owner/repos/name")
+      test.expect(res.owner).toBe("owner");
+      test.expect(res.organization).toBe("owner");
+      test.expect(res.name).toBe("name");
+      test.expect(res.full_name).toBe("owner/name");
+    });
+
+    test.should("parse Bitbucket Server root endpoint with trailing slash", () => {
+      var res = gitUrlParse("https://bitbucket.mycompany.com/projects/owner/repos/name/")
+      test.expect(res.owner).toBe("owner");
+      test.expect(res.organization).toBe("owner");
+      test.expect(res.name).toBe("name");
+      test.expect(res.full_name).toBe("owner/name");
+    });
+
+    test.should("parse Bitbucket Server commit endpoint", () => {
+      var res = gitUrlParse("https://bitbucket.mycompany.com/projects/owner/repos/name/commits/9c6443245ace92d237b7b274d4606a616e071c4e")
+      test.expect(res.owner).toBe("owner");
+      test.expect(res.organization).toBe("owner");
+      test.expect(res.name).toBe("name");
+      test.expect(res.full_name).toBe("owner/name");
+      test.expect(res.commit).toBe("9c6443245ace92d237b7b274d4606a616e071c4e")
     });
 
     // https cloudforge


### PR DESCRIPTION
This pull request will enhance the support for Bitbucket Server http(s) urls.

It will parse the `/commits/<sha1|branch>` endpoints. It will also correctly parse the owner and name when you only have the root url to a repository e.g. https://bitbucket.mycompany.com/projects/owner/repos/name