### PR TITLE
Fix parsing Bitbucket Server urls with files located in subfolders

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -216,7 +216,7 @@ function gitUrlParse(url) {
           if(["raw","browse"].indexOf(splits[1]) >= 0) {
             urlInfo.filepathtype = splits[1];
             if (splits.length > 2) {
-              urlInfo.filepath = splits[2];
+              urlInfo.filepath = splits.slice(2).join('/');
             }
           } else if(splits[1] === "commits" && splits.length > 2) {
             urlInfo.commit = splits[2];

--- a/test/index.js
+++ b/test/index.js
@@ -269,6 +269,11 @@ tester.describe("parse urls", test => {
       test.expect(res.commit).toBe("9c6443245ace92d237b7b274d4606a616e071c4e")
     });
 
+    test.should("parse Bitbucket Server with subfolder", () => {
+      var res = gitUrlParse("https://bitbucket.mycompany.com/projects/owner/repos/name/browse/entities/filename.yaml")
+      test.expect(res.filepath).toBe("entities/filename.yaml");
+    });
+
     // https cloudforge
     test.should("parse CloudForge urls", () => {
         var res = gitUrlParse("https://owner@organization.git.cloudforge.com/name.git");


### PR DESCRIPTION
#128 introduced a bug when parsing Bitbucket Server file urls for files located in a subfolder.

This pull request will make sure that we correctly get the full `filepath` instead of only the first folder.