### PR TITLE
Add `edit` filepathtype support

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -153,12 +153,14 @@ function gitUrlParse(url) {
                 const commitIndex = splits.indexOf("commit", 2);
                 const srcIndex = splits.indexOf("src", 2);
                 const rawIndex = splits.indexOf("raw", 2);
+                const editIndex = splits.indexOf("edit", 2);
                 nameIndex = dashIndex > 0 ? dashIndex - 1
                           : blobIndex > 0 ? blobIndex - 1
                           : treeIndex > 0 ? treeIndex - 1
                           : commitIndex > 0 ? commitIndex - 1
                           : srcIndex > 0 ? srcIndex - 1
                           : rawIndex > 0 ? rawIndex - 1
+                          : editIndex > 0 ? editIndex - 1
                           : nameIndex;
 
                 urlInfo.owner = splits.slice(0, nameIndex).join('/');
@@ -172,8 +174,9 @@ function gitUrlParse(url) {
             urlInfo.filepathtype = "";
             urlInfo.filepath = "";
             const offsetNameIndex = splits.length > nameIndex && splits[nameIndex+1] === "-" ? nameIndex + 1 : nameIndex;
-            if ((splits.length > offsetNameIndex + 2) && (["raw","src","blob", "tree"].indexOf(splits[offsetNameIndex + 1]) >= 0)) {
-                urlInfo.filepathtype = splits[offsetNameIndex + 1];
+
+            if ((splits.length > offsetNameIndex + 2) && (["raw", "src", "blob", "tree", "edit"].indexOf(splits[offsetNameIndex + 1]) >= 0)) {
+              urlInfo.filepathtype = splits[offsetNameIndex + 1];
                 urlInfo.ref = splits[offsetNameIndex + 2];
                 if (splits.length > offsetNameIndex + 3) {
                     urlInfo.filepath = splits.slice(offsetNameIndex + 3).join('/');

--- a/test/index.js
+++ b/test/index.js
@@ -410,7 +410,7 @@ tester.describe("parse urls", test => {
         }
 
         // execute for raw, src, blob, and tree
-        ['blob', 'raw', 'blob', 'tree', 'edit'].forEach(testForFilepathtypeURL);
+        ['raw', 'blob', 'tree', 'edit'].forEach(testForFilepathtypeURL);
     });
 
     // shorthand urls

--- a/test/index.js
+++ b/test/index.js
@@ -396,25 +396,21 @@ tester.describe("parse urls", test => {
         test.expect(res.filepathtype).toBe("blob");
         test.expect(res.filepath).toBe("test/index.js");
 
-        res = gitUrlParse("https://gitlab.com/a/b/c/d/blob/master/test/index.js");
-        test.expect(res.protocol).toBe("https");
-        test.expect(res.source).toBe("gitlab.com");
-        test.expect(res.owner).toBe("a/b/c");
-        test.expect(res.name).toBe("d");
-        test.expect(res.href).toBe("https://gitlab.com/a/b/c/d/blob/master/test/index.js");
-        test.expect(res.ref).toBe("master");
-        test.expect(res.filepathtype).toBe("blob");
-        test.expect(res.filepath).toBe("test/index.js");
+        function testForFilepathtypeURL(type) {
+            res = gitUrlParse(`https://gitlab.com/a/b/c/d/${type}/master/test/index.js`);
 
-        res = gitUrlParse("https://gitlab.com/a/b/c/d/-/blob/master/test/index.js");
-        test.expect(res.protocol).toBe("https");
-        test.expect(res.source).toBe("gitlab.com");
-        test.expect(res.owner).toBe("a/b/c");
-        test.expect(res.name).toBe("d");
-        test.expect(res.href).toBe("https://gitlab.com/a/b/c/d/-/blob/master/test/index.js");
-        test.expect(res.ref).toBe("master");
-        test.expect(res.filepathtype).toBe("blob");
-        test.expect(res.filepath).toBe("test/index.js");
+            test.expect(res.protocol).toBe("https");
+            test.expect(res.source).toBe("gitlab.com");
+            test.expect(res.owner).toBe("a/b/c");
+            test.expect(res.name).toBe("d");
+            test.expect(res.href).toBe(`https://gitlab.com/a/b/c/d/${type}/master/test/index.js`);
+            test.expect(res.ref).toBe("master");
+            test.expect(res.filepathtype).toBe(type);
+            test.expect(res.filepath).toBe("test/index.js");
+        }
+
+        // execute for raw, src, blob, and tree
+        ['blob', 'raw', 'blob', 'tree', 'edit'].forEach(testForFilepathtypeURL);
     });
 
     // shorthand urls


### PR DESCRIPTION
Hi 👋 

In order to have this link parsed correctly:
```
https://github.com/React95/React95/edit/master/README.md
```
we need to support the `edit` file path type. 

Here is a link for the issue I'm talking about:
https://stackblitz.com/edit/vitejs-vite-gv8qby?file=src%2Fmain.ts&terminal=dev

