### PR TITLE
git-url-parse 13.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,25 +274,24 @@ If you are using this library in one of your projects, add it in this list. :spa
  - `@backstage/integration`
  - `@pvm/core`
  - `@kadira/storybook-deployer`
- - `gatsby-source-git`
  - `workspace-tools`
- - `@backstage/plugin-scaffolder-backend`
+ - `gatsby-source-git`
  - `@backstage/plugin-catalog-backend`
- - `umi-build-dev`
+ - `@backstage/plugin-scaffolder-backend`
  - `@lerna-lite/core`
+ - `umi-build-dev`
+ - `@nuxt/telemetry`
  - `@era-ci/utils`
  - `@atomist/automation-client-ext-raven`
  - `git-source`
- - `@nuxt/telemetry`
  - `semantic-release-gitmoji`
  - `@qiwi/semantic-release-gh-pages-plugin`
  - `@atomist/sdm-pack-analysis`
  - `apify-shared`
  - `@git-stack/server-core`
- - `strapi-generate-new`
- - `query-registry`
- - `common-boilerplate`
  - `remax-stats`
+ - `strapi-generate-new`
+ - `common-boilerplate`
  - `renovate`
  - `@backstage/plugin-techdocs-node`
  - `@s-ui/studio`
@@ -308,70 +307,69 @@ If you are using this library in one of your projects, add it in this list. :spa
  - `datoit-generate-new`
  - `@appirio/appirio`
  - `@backstage/plugin-techdocs`
- - `beachball`
  - `@log4brains/core`
  - `@xdn/cli`
  - `@atomist/skill`
  - `@koumoul/gh-pages-multi`
- - `@pvm/gitlab`
  - `@zeplin/cli`
+ - `@pvm/gitlab`
  - `@atomist/cli`
  - `@brisk-docs/gatsby-generator`
  - `@microservices/cli`
  - `@vamsikc/plugin-catalog`
  - `hzero-block-sdk`
  - `@spryker-lerna/github-client`
+ - `gitbook-start-plugin-iaas-ull-es-noejaco2017`
+ - `omg`
  - `clipped`
  - `fotingo`
  - `git-issues`
- - `gitbook-start-plugin-iaas-ull-es-noejaco2017`
- - `@guardian/cdk`
- - `omg`
  - `@stackbit/dev-common`
+ - `@guardian/cdk`
  - `lambda-service`
  - `octokit-downloader`
  - `stylelint-formatter-utils`
  - `sync-repos`
  - `@enkeledi/react-native-week-month-date-picker`
+ - `copy-github-directory`
  - `@kevinbds/techdocs-common`
  - `docula-ui`
  - `@s-ui/mono`
- - `copy-github-directory`
  - `@facadecompany/ignition-ui`
  - `@focusworkstemp/project-utils`
- - `@geut/git-url-parse`
  - `@git-stack/hemera-plugin`
  - `@jaredpalmer/workspace-tools`
  - `@unibtc/release-it`
  - `scaffolder-core`
  - `testarmada-midway`
  - `autorelease-setup`
- - `sherry-utils`
- - `wiby`
+ - `@geut/git-url-parse`
  - `@erquhart/lerna-github-client`
  - `@oumi/cli-ui`
- - `@yarnpkg/plugin-git`
+ - `wiby`
+ - `sherry-utils`
  - `changelog.md`
- - `@feizheng/next-git-url`
- - `@0x-lerna-fork/github-client`
- - `@atomist/uhura`
- - `@iceworks/project-utils`
- - `@hygiene/plugin-github-url`
- - `@pmworks/project-utils`
+ - `@yarnpkg/plugin-git`
  - `@pubbo/github-client`
  - `@sanv/apify-shared`
- - `@antv/gatsby-theme-antv`
+ - `@0x-lerna-fork/github-client`
+ - `@atomist/uhura`
+ - `@pmworks/project-utils`
+ - `@feizheng/next-git-url`
+ - `@hygiene/plugin-github-url`
+ - `@iceworks/project-utils`
  - `gcpayz-block-sdk`
- - `documentation-custom-markdown`
  - `generator-clearphp`
- - `@scafflater/scafflater`
+ - `documentation-custom-markdown`
+ - `@antv/gatsby-theme-antv`
  - `@backstage/plugin-scaffolder`
- - `@buschtoens/documentation`
+ - `@scafflater/scafflater`
  - `@brisk-docs/website`
+ - `@buschtoens/documentation`
  - `@dandean/storybook-deployer`
- - `@dougkulak/semantic-release-gh-pages-plugin`
  - `@emedvedev/renovate`
- - `@geut/git-compare-template`
+ - `@dougkulak/semantic-release-gh-pages-plugin`
+ - `@hemith/react-native-tnk`
  - `@hugomrdias/documentation`
  - `@pageshare/cli`
  - `@merna/github-client`
@@ -407,42 +405,47 @@ If you are using this library in one of your projects, add it in this list. :spa
  - `rn-adyen-dropin`
  - `simple-github-release`
  - `snipx`
- - `react-native-arunmeena1987`
  - `react-native-contact-list`
- - `react-native-payu-payment-testing`
+ - `react-native-biometric-authenticate`
+ - `react-native-arunmeena1987`
  - `react-native-is7`
- - `react-native-my-first-try-arun-ramya`
  - `react-native-kakao-maps`
+ - `react-native-my-first-try-arun-ramya`
+ - `react-native-payu-payment-testing`
+ - `quinntainer`
+ - `qts-fission`
  - `react-native-ytximkit`
- - `vuepress-plugin-remote-url`
- - `@mmomtchev/documentation`
- - `spk`
  - `release-it-http`
- - `todo2issue`
+ - `spk`
+ - `@mmomtchev/documentation`
  - `tooling-personal`
+ - `todo2issue`
+ - `vuepress-plugin-remote-url`
  - `tmplr`
- - `prep-barv11`
- - `belt-repo`
- - `@gasket/plugin-metrics`
- - `@axetroy/gpm`
- - `@belt/repo`
- - `@cliz/gpm`
- - `docula-ui-express`
- - `@positionex/position-sdk`
  - `gitlab-ci-variables-cli`
+ - `gtni`
+ - `gitc`
  - `gitbook-start-iaas-bbdd-alex-moi`
  - `gitbook-start-iaas-ull-es-merquililycony`
- - `gitc`
  - `lcov-server`
- - `gtni`
- - `@blackglory/git-list`
+ - `@cliz/gpm`
+ - `docula-ui-express`
+ - `prep-barv11`
+ - `@axetroy/gpm`
+ - `@belt/repo`
+ - `belt-repo`
+ - `@geut/git-compare-template`
+ - `@gasket/plugin-metrics`
+ - `cover-builder`
+ - `@positionex/position-sdk`
+ - `ewizard-cli`
+ - `@1coin178/github-compare`
+ - `@arcanis/sherlock`
  - `@cilyn/bitbucket`
  - `@corelmax/react-native-my2c2p-sdk`
  - `@csmith/release-it`
- - `@1coin178/github-compare`
  - `@esops/publish-github-pages`
  - `@felipesimmi/react-native-datalogic-module`
- - `@geut/chan-parser`
  - `@narfeta/catalog-backend`
  - `@hawkingnetwork/react-native-tab-view`
  - `@infinitecsolutions/storybook-deployer`
@@ -453,7 +456,6 @@ If you are using this library in one of your projects, add it in this list. :spa
  - `generate-github-directory`
  - `git-url-promise`
  - `git-observer`
- - `github-assistant`
  - `github-action-readme`
  - `coc-discord-rpc`
  - `@xyz/create-package`
@@ -464,57 +466,68 @@ If you are using this library in one of your projects, add it in this list. :spa
  - `drowl-base-theme-iconset`
  - `dx-scanner`
  - `native-apple-login`
- - `nmrium-cli`
  - `react-native-cplus`
  - `npm_qwerty`
  - `patchanon-cli`
  - `pbc`
  - `wsj.gatsby-source-git`
  - `semantic-release-github-milestones`
- - `react-native-bubble-chart`
  - `tldw`
  - `react-native-arunjeyam1987`
  - `publish-version`
- - `@githubnext/blocks`
- - `react-native-flyy`
- - `@evanpurkhiser/tooling-personal`
- - `@shopgate/pwa-releaser`
- - `complan`
- - `def-core`
- - `@stackbit/cli`
- - `pr-log`
  - `generator-openapi-repo`
  - `github-publish-npm`
+ - `pr-log`
+ - `complan`
+ - `@shopgate/pwa-releaser`
+ - `react-native-bubble-chart`
+ - `@geut/chan-parser`
+ - `@evanpurkhiser/tooling-personal`
+ - `@blackglory/git-list`
+ - `nmrium-cli`
+ - `github-assistant`
  - `@tmplr/node`
- - `kontinuous`
+ - `react-native-flyy`
+ - `@stackbit/cli`
+ - `@edgio/cli`
+ - `@react-18-pdf/root`
+ - `@wekanteam/documentation`
+ - `@1nd/documentation`
+ - `@amorist/gatsby-theme-antd`
+ - `@apardellass/react-native-audio-stream`
+ - `@campus-online/gatsby-source-git`
+ - `@carrotwu/wcli`
+ - `@docomodigital/pdor`
+ - `@cyber-tools/cyber-npm`
+ - `@cratosw/gatsby-antd`
+ - `@domestika/mono`
+ - `@git-stack/module-server`
+ - `@geeky-apo/react-native-advanced-clipboard`
+ - `@lerna-test-v1/git`
+ - `@patrickhulce/scripts`
+ - `@saad27/react-native-bottom-tab-tour`
  - `@tjmonsi/generator-uplb-hci-lab-project-template`
  - `@tjmonsi/generator-project-template`
  - `@vicoders/cli2`
  - `@voodeng/archive`
- - `@lerna-test-v1/git`
- - `@saad27/react-native-bottom-tab-tour`
- - `@patrickhulce/scripts`
- - `canarist`
- - `candlelabssdk`
- - `cirodown`
- - `aral-vps-test`
  - `auto-clone`
- - `detect-node-support`
- - `committing`
- - `@stagas/documentation-fork`
+ - `aral-vps-test`
+ - `cirodown`
+ - `candlelabssdk`
+ - `canarist`
  - `@tagoro9/git`
+ - `committing`
+ - `detect-node-support`
  - `gatsby-theme-art-graph`
- - `gatsby-theme-cone-oc`
- - `generate-preview`
  - `generator-bootstrap-boilerplate-template`
+ - `gatsby-theme-cone-oc`
  - `@turborepo/workspace-tools`
  - `git-imitate`
- - `git-upstream`
  - `github-books`
+ - `git-upstream`
  - `react-native-dsphoto-module`
  - `react-native-responsive-size`
  - `react-native-sayhello-module`
- - `react-feedback-sdk`
  - `learning-journal-ci`
  - `just-dev-sdk`
  - `meta-release`
@@ -525,52 +538,57 @@ If you are using this library in one of your projects, add it in this list. :spa
  - `payutesting`
  - `sn-flutter-boot`
  - `umi-plugin-repo`
- - `@jupiterone/graph-checkmarx`
  - `wp-continuous-deployment`
- - `yarn-upgrade-on-ci`
  - `@axetroy/git-clone`
  - `branch-release`
  - `semantic-release-telegram`
  - `gatsby-theme-iot`
- - `@dvcorg/cml`
- - `@gogogosir/build-cli`
  - `download-repo-cli`
- - `@pvm/github`
- - `documentation-markdown-themes`
  - `gd-cli`
- - `gitline`
  - `gitbook-start-iaas-ull-es-alex-moi`
- - `@backstage/plugin-techdocs-module-addons-contrib`
+ - `gitline`
+ - `documentation-markdown-themes`
  - `@con-test/react-native-concent-common`
+ - `yarn-upgrade-on-ci`
+ - `@dvcorg/cml`
+ - `react-native-shekhar-bridge-test`
+ - `react-feedback-sdk`
+ - `@oiti/documentoscopy-react-native`
+ - `generate-preview`
+ - `@pvm/github`
+ - `@kb-sanity/proto-kb-plugin`
+ - `@stagas/documentation-fork`
+ - `@jupiterone/graph-checkmarx`
+ - `@gogogosir/build-cli`
+ - `@backstage/plugin-techdocs-module-addons-contrib`
+ - `@layer0/cli`
  - `@activeviam/documentation`
- - `@hjin/generator-app`
- - `@githubtraining/github-exercise-manager`
- - `@hnp/package-scripts`
- - `@epranka/create-tsx-package`
- - `@elestu/actions-dependacop`
  - `@mayahq/mayadev`
  - `@pagedip/tool-autorelease`
+ - `@elestu/actions-dependacop`
+ - `@epranka/create-tsx-package`
+ - `@githubtraining/github-exercise-manager`
+ - `@hnp/package-scripts`
+ - `@hjin/generator-app`
  - `@stavalfi/ci`
- - `myrenobatebot`
- - `node-norman`
- - `@shushuer/cli`
  - `birken-react-native-community-image-editor`
  - `cetus-cli`
- - `cc-flow`
- - `@rocket.chat/houston`
- - `create-sourcegraph-extension`
+ - `@shushuer/cli`
  - `create-release-it`
+ - `create-sourcegraph-extension`
  - `gatsby-theme-hansin`
  - `git-multi-profile`
  - `gitlab-tool-cli`
  - `luojia-cli-dev`
  - `mdxbook`
+ - `myrenobatebot`
+ - `node-norman`
  - `reac-native-arun-ramya-test`
- - `react-native-transtracker-library`
+ - `react-native-plugpag-wrapper`
  - `react-native-pulsator-native`
  - `react-native-arun-ramya-test`
  - `react-native-arunramya151`
- - `release2hub`
+ - `react-native-transtracker-library`
  - `@s-ui/changelog`
  - `vscode-gpm`
  - `sinanews-flutter-boot`
@@ -585,26 +603,28 @@ If you are using this library in one of your projects, add it in this list. :spa
  - `gitbook-start-https-alex-moi`
  - `mira`
  - `moto-connector`
- - `@screeb/react-native`
  - `nodeschool-admin`
  - `ogh`
  - `one-more-gitlab-cli`
- - `airbyte-faros-destination`
- - `kube-workflow`
  - `ship-release`
  - `ssh-remote`
  - `strapper`
+ - `@jfilipe-sparta/react-native-module_2`
+ - `@rocket.chat/houston`
+ - `@saleor/cli`
+ - `cogoportutils`
+ - `airbyte-faros-destination`
+ - `release2hub`
+ - `cc-flow`
+ - `kube-workflow`
  - `@backstage/plugin-catalog-import`
  - `@cythral/renovate`
  - `@epranka/create-package`
- - `@gvhinks/wiby`
  - `@generates/kdot`
  - `@georgs/beachball`
  - `@limejs/cli`
- - `@atomist/ci-sdm`
  - `@bcgov/gatsby-source-github-raw`
- - `@buganto/client`
- - `@cloudoki/donderflow`
+ - `@atomist/ci-sdm`
  - `@makepad/puppeteer-cli`
  - `@mockswitch/cli`
  - `@rescribe/cli`
@@ -629,7 +649,6 @@ If you are using this library in one of your projects, add it in this list. :spa
  - `gatsby-source-github-raw`
  - `git-csv`
  - `git-cherry-fix`
- - `gitex-flow`
  - `git-push-pr`
  - `kit-command`
  - `l2forlerna`
@@ -638,9 +657,6 @@ If you are using this library in one of your projects, add it in this list. :spa
  - `native-google-login`
  - `private-beachball`
  - `raact-native-arunramya151`
- - `remote-commit-url`
- - `react-native-modal-progress-bar`
- - `react-native-test-module-hhh`
 
 
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -39,6 +39,12 @@ function gitUrlParse(url) {
         throw new Error("The url must be a string.");
     }
 
+    const shorthandRe = /^([a-z\d-]{1,39})\/([-\.\w]{1,100})$/i
+
+    if (shorthandRe.test(url)) {
+        url = `https://github.com/${url}`
+    }
+
     let urlInfo = gitUp(url)
       , sourceParts = urlInfo.resource.split(".")
       , splits = null

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "git-url-parse",
-  "version": "12.0.0",
+  "version": "13.0.0",
   "description": "A high level git url parser for common git providers.",
   "main": "lib/index.js",
   "scripts": {
@@ -29,7 +29,7 @@
     "test": "test"
   },
   "dependencies": {
-    "git-up": "^6.0.0"
+    "git-up": "^7.0.0"
   },
   "devDependencies": {
     "tester": "^1.3.1"

--- a/test/index.js
+++ b/test/index.js
@@ -424,9 +424,8 @@ tester.describe("parse urls", test => {
         var res = gitUrlParse(URLS.shorthand);
         test.expect(res.owner).toBe("42IonicaBizau");
         test.expect(res.name).toBe("git-url-parse");
-        test.expect(res.href).toBe(URLS.shorthand);
+        test.expect(res.href).toBe(res.toString());
         test.expect(res.full_name).toBe("42IonicaBizau/git-url-parse");
-        test.expect(res.href).toBe("42IonicaBizau/git-url-parse");
     });
 
     test.should("parse subdomains", () => {


### PR DESCRIPTION
### `git-url-parse@13.0.0`

 - Fix shorthand urls. Fix #147.
 - Custom SSH User support. /cc #142 -- thanks @privatenumber!

There are **breaking changes** due to the update to `parse-url@^8.0.0`. :sparkles: