### PR TITLE
re-encode owner and repository in stringify

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -302,8 +302,13 @@ function buildPath(obj) {
     case "bitbucket-server":
       return `scm/${obj.full_name}`;
     default:
-      return `${obj.full_name}`;
+      // Note: Re-encode the repository and owner names for hosting services that allow whitespace characters
+      const encoded_full_name = obj.full_name
+        .split('/')
+        .map(x => encodeURIComponent(x))
+        .join('/');
 
+      return encoded_full_name;
   }
 }
 

--- a/test/index.js
+++ b/test/index.js
@@ -502,6 +502,10 @@ tester.describe("parse urls", test => {
         var res = gitUrlParse("http://github.com/owner/name.git");
         res.user = "user";
         test.expect(res.toString()).toBe("http://user@github.com/owner/name.git");
+
+        var res = gitUrlParse("https://dev.azure.com/organization/owner%20with%20space/_git/repo%20with%20space")
+        res.user = "pat"
+        test.expect(res.toString()).toBe("https://pat@dev.azure.com/organization/owner%20with%20space/_git/repo%20with%20space")
     });
 
     // commits


### PR DESCRIPTION
As the path's components, especially owner and repository names, are decoded for all hosting environments, I re-encoded the value in the `default` implementation where the path is built. 
fixes #155 .